### PR TITLE
[SLE] Fix credentials random number sizing

### DIFF
--- a/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/pdu/PduFactoryUtil.java
+++ b/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/pdu/PduFactoryUtil.java
@@ -169,7 +169,7 @@ public class PduFactoryUtil {
             // Current time, as per CCSDS 913.1-B-2, 3.1.2.1.1
             long time = System.currentTimeMillis();
             // Random number (positive), as per CCSDS 913.1-B-2, 3.1.2.1.1
-            long randomNumber = (new Random(time).nextLong()) & 0x7FFFFFFFFFFFFFFFL;
+            long randomNumber = (new Random(time).nextInt()) & 0x7FFFFFFFL;
             // No support for microsecond resolution
             byte[] buffer = hashCredentialsData(time, 0, randomNumber, username, password);
             // The next variable is what the standard calls 'the protected'


### PR DESCRIPTION
The random number used for the credential hashing was generated/encoded on 8 bytes but spec requires the value to be in the range [0..2^31-1] (4 bytes) as described in CCSDS 913.1-B-2, §3.1.2.1.2