### PR TITLE
[SLE] Fix incorrect port identifier in bind request

### DIFF
--- a/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/si/ServiceInstance.java
+++ b/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/si/ServiceInstance.java
@@ -608,7 +608,7 @@ public abstract class ServiceInstance implements ITmlChannelObserver {
         SleBindInvocation pdu = new SleBindInvocation();
         pdu.setVersionNumber(new VersionNumber(version));
         pdu.setInitiatorIdentifier(new AuthorityIdentifier(getInitiatorIdentifier().getBytes()));
-        pdu.setResponderPortIdentifier(new PortId(getResponderIdentifier().getBytes()));
+        pdu.setResponderPortIdentifier(new PortId(getResponderPortIdentifier().getBytes()));
         pdu.setServiceType(new ApplicationIdentifier(getApplicationIdentifier().getCode()));
         pdu.setServiceInstanceIdentifier(PduFactoryUtil.buildServiceInstanceIdentifier(getServiceInstanceIdentifier(),
                 getApplicationIdentifier()));


### PR DESCRIPTION
In the bind request, the responder port identifier was set to the responder identifier instead of the responder **port** identifier.