### PR TITLE
migrate from javax to jakarta as per JEP-320 (#1)

### DIFF
--- a/eu.dariolucia.ccsds.cfdp.fx/src/main/java/module-info.java
+++ b/eu.dariolucia.ccsds.cfdp.fx/src/main/java/module-info.java
@@ -3,8 +3,7 @@ open module eu.dariolucia.ccsds.cfdp.fx {
     requires javafx.fxml;
     requires javafx.controls;
     requires java.logging;
-    requires java.xml.bind;
-    requires com.sun.xml.bind;
+    requires jakarta.xml.bind;
     requires eu.dariolucia.ccsds.cfdp;
     requires eu.dariolucia.ccsds.tmtc;
 

--- a/eu.dariolucia.ccsds.cfdp/src/main/java/eu/dariolucia/ccsds/cfdp/mib/FaultHandlerStrategy.java
+++ b/eu.dariolucia.ccsds.cfdp/src/main/java/eu/dariolucia/ccsds/cfdp/mib/FaultHandlerStrategy.java
@@ -18,9 +18,9 @@ package eu.dariolucia.ccsds.cfdp.mib;
 
 import eu.dariolucia.ccsds.cfdp.protocol.pdu.ConditionCode;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 public class FaultHandlerStrategy {

--- a/eu.dariolucia.ccsds.cfdp/src/main/java/eu/dariolucia/ccsds/cfdp/mib/LocalEntityConfigurationInformation.java
+++ b/eu.dariolucia.ccsds.cfdp/src/main/java/eu/dariolucia/ccsds/cfdp/mib/LocalEntityConfigurationInformation.java
@@ -18,7 +18,7 @@ package eu.dariolucia.ccsds.cfdp.mib;
 
 import eu.dariolucia.ccsds.cfdp.protocol.pdu.ConditionCode;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;

--- a/eu.dariolucia.ccsds.cfdp/src/main/java/eu/dariolucia/ccsds/cfdp/mib/Mib.java
+++ b/eu.dariolucia.ccsds.cfdp/src/main/java/eu/dariolucia/ccsds/cfdp/mib/Mib.java
@@ -16,11 +16,11 @@
 
 package eu.dariolucia.ccsds.cfdp.mib;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
+import jakarta.xml.bind.annotation.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/eu.dariolucia.ccsds.cfdp/src/main/java/eu/dariolucia/ccsds/cfdp/mib/RemoteEntityConfigurationInformation.java
+++ b/eu.dariolucia.ccsds.cfdp/src/main/java/eu/dariolucia/ccsds/cfdp/mib/RemoteEntityConfigurationInformation.java
@@ -16,10 +16,10 @@
 
 package eu.dariolucia.ccsds.cfdp.mib;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 public class RemoteEntityConfigurationInformation {

--- a/eu.dariolucia.ccsds.cfdp/src/main/java/module-info.java
+++ b/eu.dariolucia.ccsds.cfdp/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 open module eu.dariolucia.ccsds.cfdp {
     requires java.logging;
-    requires transitive java.xml.bind;
+    requires transitive jakarta.xml.bind;
     requires eu.dariolucia.ccsds.tmtc;
 
     exports eu.dariolucia.ccsds.cfdp.common;

--- a/eu.dariolucia.ccsds.encdec/pom.xml
+++ b/eu.dariolucia.ccsds.encdec/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~   Copyright (c) 2019 Dario Lucia (https://www.dariolucia.eu)
-  ~      
+  ~
   ~   Licensed under the Apache License, Version 2.0 (the "License");
   ~   you may not use this file except in compliance with the License.
   ~   You may obtain a copy of the License at
-  ~   
+  ~
   ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~   
+  ~
   ~   Unless required by applicable law or agreed to in writing, software
   ~   distributed under the License is distributed on an "AS IS" BASIS,
   ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,6 +38,11 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <version>${jaxb.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jakarta.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/AbstractEncodedItem.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/AbstractEncodedItem.java
@@ -16,7 +16,7 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.Objects;
 

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/AbstractEncodedLength.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/AbstractEncodedLength.java
@@ -16,8 +16,8 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/AbstractEncodedLocation.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/AbstractEncodedLocation.java
@@ -16,8 +16,8 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/AbstractEncodedType.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/AbstractEncodedType.java
@@ -16,8 +16,8 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/AbstractLinkedParameter.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/AbstractLinkedParameter.java
@@ -16,8 +16,8 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/Definition.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/Definition.java
@@ -16,11 +16,11 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
+import jakarta.xml.bind.annotation.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/EncodedArray.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/EncodedArray.java
@@ -16,10 +16,10 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElements;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElements;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/EncodedItemRelativeLocation.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/EncodedItemRelativeLocation.java
@@ -16,9 +16,9 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Objects;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/EncodedParameter.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/EncodedParameter.java
@@ -16,7 +16,7 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.Objects;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/EncodedStructure.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/EncodedStructure.java
@@ -16,10 +16,10 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElements;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElements;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/ExtensionType.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/ExtensionType.java
@@ -20,9 +20,9 @@ import eu.dariolucia.ccsds.encdec.extension.ExtensionId;
 import eu.dariolucia.ccsds.encdec.extension.IDecoderExtension;
 import eu.dariolucia.ccsds.encdec.extension.IEncoderExtension;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Objects;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/FixedAbsoluteLocation.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/FixedAbsoluteLocation.java
@@ -16,9 +16,9 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Objects;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/FixedArraySize.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/FixedArraySize.java
@@ -16,9 +16,9 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Objects;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/FixedLength.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/FixedLength.java
@@ -16,9 +16,9 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Objects;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/FixedLinkedParameter.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/FixedLinkedParameter.java
@@ -16,10 +16,10 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlIDREF;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlIDREF;
 import java.util.Objects;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/FixedType.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/FixedType.java
@@ -16,9 +16,9 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Objects;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/GenerationTime.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/GenerationTime.java
@@ -16,9 +16,9 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import java.io.Serializable;
 import java.util.Objects;
 

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/IdentField.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/IdentField.java
@@ -16,11 +16,11 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlID;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlID;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.io.Serializable;
 import java.util.Objects;
 

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/IdentFieldMatcher.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/IdentFieldMatcher.java
@@ -16,11 +16,11 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlIDREF;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlIDREF;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.io.Serializable;
 import java.util.Objects;
 

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/IntAdapter.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/IntAdapter.java
@@ -16,7 +16,7 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 
 /**
  * Integer adapter that can convert a string (hex, octal, binary, decimal) to an integer.

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/LastRelativeLocation.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/LastRelativeLocation.java
@@ -16,9 +16,9 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Objects;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/PacketDefinition.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/PacketDefinition.java
@@ -16,7 +16,7 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.LinkedList;

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/PacketStructure.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/PacketStructure.java
@@ -16,7 +16,7 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.LinkedList;

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/ParameterDefinition.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/ParameterDefinition.java
@@ -16,7 +16,7 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.Objects;
 

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/ParameterLength.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/ParameterLength.java
@@ -16,9 +16,9 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Objects;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/ParameterType.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/ParameterType.java
@@ -16,9 +16,9 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Objects;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/ReferenceArraySize.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/ReferenceArraySize.java
@@ -16,9 +16,9 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Objects;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/ReferenceLength.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/ReferenceLength.java
@@ -16,9 +16,9 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Objects;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/ReferenceLinkedParameter.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/ReferenceLinkedParameter.java
@@ -16,9 +16,9 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Objects;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/ReferenceType.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/definition/ReferenceType.java
@@ -16,9 +16,9 @@
 
 package eu.dariolucia.ccsds.encdec.definition;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Objects;
 
 /**

--- a/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/identifier/impl/FieldGroupBasedPacketIdentifier.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/eu/dariolucia/ccsds/encdec/identifier/impl/FieldGroupBasedPacketIdentifier.java
@@ -24,7 +24,7 @@ import eu.dariolucia.ccsds.encdec.identifier.IPacketIdentifier;
 import eu.dariolucia.ccsds.encdec.identifier.PacketAmbiguityException;
 import eu.dariolucia.ccsds.encdec.identifier.PacketNotIdentifiedException;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import java.util.*;
 import java.util.stream.Collectors;
 

--- a/eu.dariolucia.ccsds.encdec/src/main/java/module-info.java
+++ b/eu.dariolucia.ccsds.encdec/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 open module eu.dariolucia.ccsds.encdec {
-    requires transitive java.xml.bind;
+  requires transitive jakarta.xml.bind;
 
-    uses eu.dariolucia.ccsds.encdec.extension.ILengthMapper;
+  uses eu.dariolucia.ccsds.encdec.extension.ILengthMapper;
     uses eu.dariolucia.ccsds.encdec.extension.ITypeMapper;
     uses eu.dariolucia.ccsds.encdec.extension.IEncoderExtension;
     uses eu.dariolucia.ccsds.encdec.extension.IDecoderExtension;

--- a/eu.dariolucia.ccsds.examples/src/main/java/module-info.java
+++ b/eu.dariolucia.ccsds.examples/src/main/java/module-info.java
@@ -6,5 +6,5 @@ open module eu.dariolucia.ccsds.examples {
     requires eu.dariolucia.ccsds.tmtc;
     requires eu.dariolucia.ccsds.cfdp;
 
-    requires com.sun.xml.bind;
+    requires jakarta.xml.bind;
 }

--- a/eu.dariolucia.ccsds.sle.utl/pom.xml
+++ b/eu.dariolucia.ccsds.sle.utl/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- ~ Copyright 2018-2019 Dario Lucia (https://www.dariolucia.eu) ~ ~ Licensed 
-	under the Apache License, Version 2.0 (the "License"); ~ you may not use 
-	this file except in compliance with the License. ~ You may obtain a copy 
-	of the License at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 ~ ~ Unless 
-	required by applicable law or agreed to in writing, software ~ distributed 
-	under the License is distributed on an "AS IS" BASIS, ~ WITHOUT WARRANTIES 
-	OR CONDITIONS OF ANY KIND, either express or implied. ~ See the License for 
+<!-- ~ Copyright 2018-2019 Dario Lucia (https://www.dariolucia.eu) ~ ~ Licensed
+	under the Apache License, Version 2.0 (the "License"); ~ you may not use
+	this file except in compliance with the License. ~ You may obtain a copy
+	of the License at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 ~ ~ Unless
+	required by applicable law or agreed to in writing, software ~ distributed
+	under the License is distributed on an "AS IS" BASIS, ~ WITHOUT WARRANTIES
+	OR CONDITIONS OF ANY KIND, either express or implied. ~ See the License for
 	the specific language governing permissions and ~ limitations under the License. -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -116,6 +116,11 @@
 			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-runtime</artifactId>
 			<version>${jaxb.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>${jakarta.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/config/PeerConfiguration.java
+++ b/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/config/PeerConfiguration.java
@@ -19,8 +19,8 @@ package eu.dariolucia.ccsds.sle.utl.config;
 import eu.dariolucia.ccsds.sle.utl.config.network.PortMapping;
 import eu.dariolucia.ccsds.sle.utl.config.network.RemotePeer;
 
-import javax.xml.bind.DatatypeConverter;
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.annotation.*;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;

--- a/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/config/ServiceInstanceConfiguration.java
+++ b/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/config/ServiceInstanceConfiguration.java
@@ -19,9 +19,9 @@ package eu.dariolucia.ccsds.sle.utl.config;
 import eu.dariolucia.ccsds.sle.utl.si.ApplicationIdentifierEnum;
 import eu.dariolucia.ccsds.sle.utl.si.InitiatorRoleEnum;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 import java.util.Objects;
 
 /**

--- a/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/config/UtlConfigurationFile.java
+++ b/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/config/UtlConfigurationFile.java
@@ -21,11 +21,11 @@ import eu.dariolucia.ccsds.sle.utl.config.raf.RafServiceInstanceConfiguration;
 import eu.dariolucia.ccsds.sle.utl.config.rcf.RcfServiceInstanceConfiguration;
 import eu.dariolucia.ccsds.sle.utl.config.rocf.RocfServiceInstanceConfiguration;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
+import jakarta.xml.bind.annotation.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/config/cltu/CltuServiceInstanceConfiguration.java
+++ b/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/config/cltu/CltuServiceInstanceConfiguration.java
@@ -23,9 +23,9 @@ import eu.dariolucia.ccsds.sle.utl.si.cltu.CltuNotificationModeEnum;
 import eu.dariolucia.ccsds.sle.utl.si.cltu.CltuPlopInEffectEnum;
 import eu.dariolucia.ccsds.sle.utl.si.cltu.CltuProtocolAbortModeEnum;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 import java.util.Date;
 import java.util.Objects;
 

--- a/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/config/network/PortMapping.java
+++ b/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/config/network/PortMapping.java
@@ -16,9 +16,9 @@
 
 package eu.dariolucia.ccsds.sle.utl.config.network;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Objects;
 
 /**

--- a/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/config/network/RemotePeer.java
+++ b/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/config/network/RemotePeer.java
@@ -19,10 +19,10 @@ package eu.dariolucia.ccsds.sle.utl.config.network;
 import eu.dariolucia.ccsds.sle.utl.si.AuthenticationModeEnum;
 import eu.dariolucia.ccsds.sle.utl.si.HashFunctionEnum;
 
-import javax.xml.bind.DatatypeConverter;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Objects;
 
 /**

--- a/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/config/raf/RafServiceInstanceConfiguration.java
+++ b/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/config/raf/RafServiceInstanceConfiguration.java
@@ -21,10 +21,10 @@ import eu.dariolucia.ccsds.sle.utl.si.ApplicationIdentifierEnum;
 import eu.dariolucia.ccsds.sle.utl.si.DeliveryModeEnum;
 import eu.dariolucia.ccsds.sle.utl.si.raf.RafRequestedFrameQualityEnum;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;

--- a/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/config/rcf/RcfServiceInstanceConfiguration.java
+++ b/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/config/rcf/RcfServiceInstanceConfiguration.java
@@ -21,10 +21,10 @@ import eu.dariolucia.ccsds.sle.utl.si.ApplicationIdentifierEnum;
 import eu.dariolucia.ccsds.sle.utl.si.DeliveryModeEnum;
 import eu.dariolucia.ccsds.sle.utl.si.GVCID;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;

--- a/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/config/rocf/RocfServiceInstanceConfiguration.java
+++ b/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/config/rocf/RocfServiceInstanceConfiguration.java
@@ -23,10 +23,10 @@ import eu.dariolucia.ccsds.sle.utl.si.GVCID;
 import eu.dariolucia.ccsds.sle.utl.si.rocf.RocfControlWordTypeEnum;
 import eu.dariolucia.ccsds.sle.utl.si.rocf.RocfUpdateModeEnum;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;

--- a/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/pdu/PduFactoryUtil.java
+++ b/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/pdu/PduFactoryUtil.java
@@ -34,7 +34,7 @@ import eu.dariolucia.ccsds.sle.utl.config.network.RemotePeer;
 import eu.dariolucia.ccsds.sle.utl.si.ApplicationIdentifierEnum;
 import eu.dariolucia.ccsds.sle.utl.si.HashFunctionEnum;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/pdu/PduStringUtil.java
+++ b/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/pdu/PduStringUtil.java
@@ -16,7 +16,7 @@
 
 package eu.dariolucia.ccsds.sle.utl.pdu;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import java.util.regex.Pattern;
 
 /**

--- a/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/si/GVCID.java
+++ b/eu.dariolucia.ccsds.sle.utl/src/main/java/eu/dariolucia/ccsds/sle/utl/si/GVCID.java
@@ -16,9 +16,9 @@
 
 package eu.dariolucia.ccsds.sle.utl.si;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 
 /**
  * This class contains the information related to a permitted, requested or selected Global Virtual Channel Identifier,

--- a/eu.dariolucia.ccsds.sle.utl/src/main/java/module-info.java
+++ b/eu.dariolucia.ccsds.sle.utl/src/main/java/module-info.java
@@ -1,10 +1,9 @@
 open module eu.dariolucia.ccsds.sle.utl {
     requires jasn1;
-    requires java.xml.bind;
+    requires jakarta.xml.bind;
     requires java.logging;
-    requires com.sun.xml.bind;
 
-    exports eu.dariolucia.ccsds.sle.generated.ccsds.sle.transfer.service.isp1.credentials;
+  exports eu.dariolucia.ccsds.sle.generated.ccsds.sle.transfer.service.isp1.credentials;
     exports eu.dariolucia.ccsds.sle.generated.ccsds.sle.transfer.service.bind.types;
     exports eu.dariolucia.ccsds.sle.generated.ccsds.sle.transfer.service.common.pdus;
     exports eu.dariolucia.ccsds.sle.generated.ccsds.sle.transfer.service.common.types;

--- a/eu.dariolucia.ccsds.sle.utl/src/test/java/eu/dariolucia/ccsds/sle/utl/config/UtlConfigurationFileTest.java
+++ b/eu.dariolucia.ccsds.sle.utl/src/test/java/eu/dariolucia/ccsds/sle/utl/config/UtlConfigurationFileTest.java
@@ -32,9 +32,9 @@ import eu.dariolucia.ccsds.sle.utl.si.rocf.RocfControlWordTypeEnum;
 import eu.dariolucia.ccsds.sle.utl.si.rocf.RocfUpdateModeEnum;
 import org.junit.jupiter.api.Test;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.SchemaOutputResolver;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.SchemaOutputResolver;
 import javax.xml.transform.Result;
 import javax.xml.transform.stream.StreamResult;
 import java.io.ByteArrayInputStream;

--- a/eu.dariolucia.ccsds.sle.utl/src/test/java/eu/dariolucia/ccsds/sle/utl/test/AwaitUtil.java
+++ b/eu.dariolucia.ccsds.sle.utl/src/test/java/eu/dariolucia/ccsds/sle/utl/test/AwaitUtil.java
@@ -16,6 +16,7 @@
 
 package eu.dariolucia.ccsds.sle.utl.test;
 
+import java.time.Duration;
 import java.util.function.Supplier;
 
 public class AwaitUtil {
@@ -29,6 +30,10 @@ public class AwaitUtil {
                 break;
             }
         }
+    }
+
+    public static void awaitCondition(Duration waitLimit, Supplier<Boolean> conditionChecker) throws InterruptedException {
+        awaitCondition((int) waitLimit.toMillis(), conditionChecker);
     }
 
     public static void await(int ms) throws InterruptedException {

--- a/eu.dariolucia.ccsds.sle.utl/src/test/java/eu/dariolucia/ccsds/sle/utl/test/CltuTest.java
+++ b/eu.dariolucia.ccsds.sle.utl/src/test/java/eu/dariolucia/ccsds/sle/utl/test/CltuTest.java
@@ -36,6 +36,7 @@ import eu.dariolucia.ccsds.sle.utl.si.PeerAbortReasonEnum;
 import eu.dariolucia.ccsds.sle.utl.si.ServiceInstanceBindingStateEnum;
 import eu.dariolucia.ccsds.sle.utl.si.UnbindReasonEnum;
 import eu.dariolucia.ccsds.sle.utl.si.cltu.*;
+import java.time.Duration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -92,7 +93,7 @@ public class CltuTest {
         cltuUser.bind(2);
         AwaitUtil.awaitCondition(10000, () -> cltuProvider.getCurrentBindingState() == ServiceInstanceBindingStateEnum.UNBOUND);
         assertEquals(ServiceInstanceBindingStateEnum.UNBOUND, cltuUser.getCurrentBindingState());
-        assertEquals(1, recorder.getPduReceived().size());
+        AwaitUtil.awaitCondition(Duration.ofSeconds(10), () -> recorder.getPduReceived().size() == 1);
         assertTrue(recorder.getPduReceived().get(0) instanceof SleBindReturn);
         assertEquals(BindDiagnosticsEnum.INCONSISTENT_SERVICE_TYPE.getCode(), ((SleBindReturn) recorder.getPduReceived().get(0)).getResult().getNegative().intValue());
 

--- a/eu.dariolucia.ccsds.sle.utlfx/src/main/java/eu/dariolucia/ccsds/sle/utlfx/dialogs/CreateServiceInstanceDialog.java
+++ b/eu.dariolucia.ccsds.sle.utlfx/src/main/java/eu/dariolucia/ccsds/sle/utlfx/dialogs/CreateServiceInstanceDialog.java
@@ -35,7 +35,7 @@ import javafx.stage.FileChooser;
 import javafx.stage.StageStyle;
 import javafx.util.StringConverter;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;

--- a/eu.dariolucia.ccsds.sle.utlfx/src/main/java/eu/dariolucia/ccsds/sle/utlfx/dialogs/cltu/CltuThrowEventDialog.java
+++ b/eu.dariolucia.ccsds.sle.utlfx/src/main/java/eu/dariolucia/ccsds/sle/utlfx/dialogs/cltu/CltuThrowEventDialog.java
@@ -20,7 +20,7 @@ import java.nio.charset.Charset;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 
 import eu.dariolucia.ccsds.sle.utlfx.dialogs.cltu.CltuThrowEventDialog.CltuThrowEventDialogResult;
 import javafx.application.Platform;

--- a/eu.dariolucia.ccsds.sle.utlfx/src/main/java/eu/dariolucia/ccsds/sle/utlfx/dialogs/cltu/CltuTransferDataDialog.java
+++ b/eu.dariolucia.ccsds.sle.utlfx/src/main/java/eu/dariolucia/ccsds/sle/utlfx/dialogs/cltu/CltuTransferDataDialog.java
@@ -22,7 +22,7 @@ import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 
 import eu.dariolucia.ccsds.sle.utlfx.dialogs.cltu.CltuTransferDataDialog.CltuTransferDataDialogResult;
 import javafx.application.Platform;

--- a/eu.dariolucia.ccsds.sle.utlfx/src/main/java/eu/dariolucia/ccsds/sle/utlfx/manager/SlePduAttribute.java
+++ b/eu.dariolucia.ccsds.sle.utlfx/src/main/java/eu/dariolucia/ccsds/sle/utlfx/manager/SlePduAttribute.java
@@ -19,7 +19,7 @@ package eu.dariolucia.ccsds.sle.utlfx.manager;
 import com.beanit.jasn1.ber.types.*;
 import com.beanit.jasn1.ber.types.string.BerVisibleString;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import java.util.Arrays;
 
 public class SlePduAttribute {

--- a/eu.dariolucia.ccsds.sle.utlfx/src/main/java/module-info.java
+++ b/eu.dariolucia.ccsds.sle.utlfx/src/main/java/module-info.java
@@ -4,8 +4,7 @@ module eu.dariolucia.ccsds.sle.utlfx {
     requires javafx.controls;
     requires java.logging;
     requires jasn1;
-    requires java.xml.bind;
-    requires com.sun.xml.bind;
+    requires jakarta.xml.bind;
     requires eu.dariolucia.ccsds.sle.utl;
 
     exports eu.dariolucia.ccsds.sle.utlfx.manager;

--- a/eu.dariolucia.ccsds.viewer/src/main/java/eu/dariolucia/ccsds/viewer/utils/SlePduAttribute.java
+++ b/eu.dariolucia.ccsds.viewer/src/main/java/eu/dariolucia/ccsds/viewer/utils/SlePduAttribute.java
@@ -19,7 +19,7 @@ package eu.dariolucia.ccsds.viewer.utils;
 import com.beanit.jasn1.ber.types.*;
 import com.beanit.jasn1.ber.types.string.BerVisibleString;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import java.util.Arrays;
 
 public class SlePduAttribute {

--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,10 @@
         <!-- Java version -->
         <java.version>11</java.version>
         <!-- External libraries versions -->
-        <junit.version>5.5.0-M1</junit.version>
-        <openjfx.version>11.0.2</openjfx.version>
-        <jaxb.version>2.3.1</jaxb.version>
+        <junit.version>5.10.0-M1</junit.version>
+        <openjfx.version>19.0.2.1</openjfx.version>
+        <jakarta.version>4.0.0</jakarta.version>
+        <jaxb.version>4.0.2</jaxb.version>
         <jasn1.version>1.11.2</jasn1.version>
         <antlr.version>2.7.7</antlr.version>
         <!-- Maven plugin versions -->
@@ -68,8 +69,8 @@
         <maven.javadoc.version>3.1.0</maven.javadoc.version>
         <maven.jar.version>2.4</maven.jar.version>
         <maven.source.version>3.1.0</maven.source.version>
-        <maven.surefire.version>2.22.2</maven.surefire.version>
-        <maven.compiler.version>3.8.1</maven.compiler.version>
+        <maven.surefire.version>3.1.2</maven.surefire.version>
+        <maven.compiler.version>3.11.0</maven.compiler.version>
         <maven.gpg.version>1.6</maven.gpg.version>
         <maven.version>2.5</maven.version>
         <maven.bundle.version>5.1.8</maven.bundle.version>


### PR DESCRIPTION
There is a nice summary on the why here:
https://www.jesperdj.com/2018/09/30/jaxb-on-java-9-10-11-and-beyond/

Also fixed a flaky test where a quick machine could get the received PDU (`CopyOnWriteArrayList`) before the write was complete. `CopyOnWriteArrayList` maintains the old reference (to the backing array) for reads whilst it is adding new data.

I updated a few plugins you might want to double check :grin: 

Builds pass on JDK 11 and 17 although the sonar checks don't run since (as expected) I don't have the sonar key.

It's also ready for Spring boot 3 environment which has moved to Jakarta.